### PR TITLE
feat(ibverbs): implement the basic framework for dlopen method

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -112,7 +112,7 @@ PenaltyReturnTypeOnItsOwnLine: 60
 
 PointerAlignment: Right
 ReflowComments: false
-SortIncludes: false
+SortIncludes: true
 #SortUsingDeclarations: false # Unknown to clang-format-4.0
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ add_library(ibverbs STATIC
 target_include_directories(ibverbs
     PUBLIC
         ${PROJECT_SOURCE_DIR}/include
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/src
 )
 
 target_link_libraries(ibverbs
@@ -23,9 +25,13 @@ add_library(rdmacm STATIC
 target_include_directories(rdmacm
     PUBLIC
         ${PROJECT_SOURCE_DIR}/include
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/src
 )
 
 target_link_libraries(rdmacm
     PRIVATE
         ${CMAKE_DL_LIBS}
 )
+
+add_subdirectory(examples EXCLUDE_FROM_ALL)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,6 @@
+add_executable(hello_ibverbs hello_ibverbs.c)
+
+target_link_libraries(hello_ibverbs
+    PRIVATE
+        ibverbs
+)

--- a/examples/hello_ibverbs.c
+++ b/examples/hello_ibverbs.c
@@ -1,0 +1,19 @@
+#include <infiniband/verbs.h>
+#include <stdio.h>
+
+int main()
+{
+	int num_devices = 0;
+	struct ibv_device **devices = ibv_get_device_list(&num_devices);
+	if (devices == NULL) {
+		perror("ibv_get_device_list failed");
+		return -1;
+	}
+	printf("got %d devices\n", num_devices);
+	for (int i = 0; i != num_devices; ++i) {
+		printf("\tdevice %d: name=%s\n", i,
+		       ibv_get_device_name(devices[i]));
+	}
+	ibv_free_device_list(devices);
+	return 0;
+}

--- a/src/ibverbs.c
+++ b/src/ibverbs.c
@@ -1,5 +1,52 @@
 #include "infiniband/verbs.h"
+#include "utility.h"
+#include <dlfcn.h>
+#include <errno.h>
+
+#define DEFINE_WRAPPER_FUNC_IBV(_symbol, _ret, ...)                            \
+	DEFINE_WRAPPER_FUNC_COMMON(ibv_, _symbol, _ret, __VA_ARGS__)
+
+#define LOAD_FUNC_PTR_IBV(_handle, _symbol)                                    \
+	LOAD_FUNC_PTR_COMMON(ibv_, _handle, _symbol)
+
+DEFINE_WRAPPER_FUNC_IBV(get_device_list, struct ibv_device **, int *num_devices)
+{
+	if (UNLIKELY(!FUNC_PTR(get_device_list))) {
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+	return FUNC_PTR(get_device_list)(num_devices);
+}
+
+DEFINE_WRAPPER_FUNC_IBV(free_device_list, void, struct ibv_device **list)
+{
+	if (UNLIKELY(!FUNC_PTR(free_device_list))) {
+		errno = EOPNOTSUPP;
+		return;
+	}
+	return FUNC_PTR(free_device_list)(list);
+}
+
+DEFINE_WRAPPER_FUNC_IBV(get_device_name, const char *,
+			struct ibv_device *device)
+{
+	if (UNLIKELY(!FUNC_PTR(get_device_name))) {
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+	return FUNC_PTR(get_device_name)(device);
+}
 
 static __attribute__((constructor)) void ibverbs_init(void)
 {
+	void *handle = dlopen("libibverbs.so.1", RTLD_LAZY | RTLD_LOCAL);
+	if (UNLIKELY(!handle)) {
+		// TODO(fuji): log error msg
+		return;
+	}
+	LOAD_FUNC_PTR_IBV(handle, get_device_list);
+	LOAD_FUNC_PTR_IBV(handle, free_device_list);
+	LOAD_FUNC_PTR_IBV(handle, get_device_name);
+	// do not dlclose the handle in destructor to avoid dereferencing a NULL
+	// function pointer during the teardown stage of the process
 }

--- a/src/utility.h
+++ b/src/utility.h
@@ -1,0 +1,28 @@
+#ifndef UTILITY_H
+#define UTILITY_H
+
+#include <dlfcn.h>
+#include <stddef.h>
+
+#define LIKELY(x) __builtin_expect(!!(x), 1)
+#define UNLIKELY(x) __builtin_expect(!!(x), 0)
+
+#define STRINGIFY(x) #x
+
+// convert symbol name to function pointer name
+#define FUNC_PTR(_symbol) __wrapper_##_symbol
+
+// common macro to define wrapper function
+#define DEFINE_WRAPPER_FUNC_COMMON(_prefix, _symbol, _ret, ...)                \
+	static _ret (*FUNC_PTR(_symbol))(__VA_ARGS__) = NULL;                  \
+	extern _ret _prefix##_symbol(__VA_ARGS__)
+
+#define LOAD_FUNC_PTR_COMMON(_prefix, _handle, _symbol)                        \
+	do {                                                                   \
+		FUNC_PTR(_symbol) =                                            \
+			dlsym(_handle, STRINGIFY(_prefix##_symbol));           \
+		if (UNLIKELY(!FUNC_PTR(_symbol))) {                            \
+		}                                                              \
+	} while (0)
+
+#endif /* UTILITY_H */


### PR DESCRIPTION
Use dlsym to load several symbols from libibverbs to verify the functionality. Add a minimal example for querying the RDMA devices.